### PR TITLE
Added npmArgs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ In your project's Gruntfile, add a section named `dependency_installer` to the d
 grunt.initConfig({
   dependency_installer: {
     options: {
-      pluginDir: 'plugins'
+      pluginDir: 'plugins',
+      npmArgs: '--cache ./.npm-cache'
     }
   },
 })
@@ -46,6 +47,11 @@ Default value: `'plugins'`
 
 Relative path to your private plugins.
 
+#### options.npmArgs
+Type: `String`
+Default value: `''`
+
+Additional arguments to pass to `npm install`
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).

--- a/tasks/dependency_installer.js
+++ b/tasks/dependency_installer.js
@@ -16,7 +16,8 @@ module.exports = function(grunt) {
   grunt.registerTask('dependency_installer', 'A Grunt plugin for installing dependancies to node modules stored in the plugins directory', function() {
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
-      pluginsDir: 'plugins'
+      pluginsDir: 'plugins',
+      npmArgs: ''
     }),
         done = this.async(),
         plugins = [],
@@ -29,7 +30,7 @@ module.exports = function(grunt) {
     // Install dependencies
     var npmInstall = function(thisPackage, callback) {
       var cd = 'cd ' + process.cwd() + '/' + options.pluginsDir + '/' + thisPackage,
-          command = cd + ' && npm install';
+          command = cd + ' && npm install ' + options.npmArgs;
 
       childProcess.exec(command, cmdOpts,function(err, stdout, stderr) {
         if (err) throw err;


### PR DESCRIPTION
This adds the option to pass arguments to `npm install`.
Useful if you want to use a local npm cache directory, for example.
